### PR TITLE
Add pretty flag to prettify output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +365,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +499,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "flate2",
+ "pretty-bytes",
  "swc",
  "swc_ecmascript",
 ]
@@ -816,6 +837,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty-bytes"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009d6edd2c1dbf2e1c0cd48a2f7766e03498d49ada7109a01c6911815c685316"
+dependencies = [
+ "atty",
+ "getopts",
+]
 
 [[package]]
 name = "proc-macro-hack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ flate2 = "1.0.22"
 anyhow = "1.0.41"
 swc = { version = "0.87.2" }
 swc_ecmascript = { version = "0.88.1", features = ["minifier"] }
+pretty-bytes = "0.2.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,28 @@
+use js_sizers::compress;
+use pretty_bytes::converter::convert;
 use std::env;
 use std::fs;
-use js_sizers::{compress};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
     let filename = &args[1];
+    let flag = args.get(2).map(|s| s.as_str()).unwrap_or("");
 
     println!("Reading file: {}...\n", filename);
 
     let code = fs::read_to_string(filename).expect("Could not read file");
     let output = compress(&code);
 
-    println!("origin: {} bytes", output.origin);
-    println!("minified: {} bytes", output.minified);
-    println!("gzipped: {} bytes", output.gzip);
+    match flag {
+        "--pretty" | "-p" => {
+            println!("origin: {}", convert(output.origin as f64));
+            println!("minified: {}", convert(output.minified as f64));
+            println!("gzipped: {}", convert(output.gzip as f64));
+        }
+        _ => {
+            println!("origin: {} bytes", output.origin);
+            println!("minified: {} bytes", output.minified);
+            println!("gzipped: {} bytes", output.gzip);
+        }
+    }
 }


### PR DESCRIPTION
`cargo run ./test.js`

```
Reading file: ./test.js...

origin: 3724 bytes
minified: 1911 bytes
gzipped: 867 bytes
```

`cargo run ./test.js -p`
```
Reading file: ./test.js...

origin: 3.72 kB
minified: 1.91 kB
gzipped: 867 B
```